### PR TITLE
Add load/save query logic, settings

### DIFF
--- a/DBViewer.pro
+++ b/DBViewer.pro
@@ -26,11 +26,13 @@ DEFINES += QT_DEPRECATED_WARNINGS
 SOURCES += \
         main.cpp \
         mainwindow.cpp \
-    database.cpp
+    database.cpp \
+    settings.cpp
 
 HEADERS += \
         mainwindow.h \
-    database.h
+    database.h \
+    settings.h
 
 FORMS += \
         mainwindow.ui

--- a/database.cpp
+++ b/database.cpp
@@ -40,3 +40,69 @@ QStringList database::get_sql_queries()
 
     return rtnSqlQueries;
 }
+
+void database::set_default_filedialog_dir(QFileDialog * dialogToSetDefaultDir)
+{
+    if(settings::PathApplication != "")
+    {
+        QString pathSavedSQL = settings::PathApplication + QDir::separator() + "saved_sql";
+
+        QDir dirSavedSQL;
+        if(!dirSavedSQL.exists(pathSavedSQL))
+        {
+            dirSavedSQL.mkdir(pathSavedSQL);
+        }
+
+        dialogToSetDefaultDir->setDirectory(pathSavedSQL);
+    }
+}
+
+void database::save_sql_query(QString sqlQueryTextToBeSaved)
+{
+    QFileDialog saveSQLQueryDialog;
+    saveSQLQueryDialog.setModal(true);
+    saveSQLQueryDialog.setAcceptMode(QFileDialog::AcceptSave);
+    saveSQLQueryDialog.setViewMode(QFileDialog::ViewMode::Detail);
+    saveSQLQueryDialog.setDefaultSuffix("sql");
+
+    set_default_filedialog_dir(&saveSQLQueryDialog);
+
+    if(saveSQLQueryDialog.exec())
+    {
+        QString savedFileName = saveSQLQueryDialog.selectedFiles().at(0);
+
+        QFile saveFile(savedFileName);
+        saveFile.open(QFile::OpenModeFlag::WriteOnly);
+
+        QByteArray bufferOfDataToWrite = sqlQueryTextToBeSaved.toLocal8Bit();
+        const char * dataToWrite = bufferOfDataToWrite.data();
+
+        saveFile.write(dataToWrite);
+        saveFile.close();
+    }
+}
+
+void database::load_sql_query(QTextEdit * textEditWidgetToLoadSQLInto)
+{
+    QFileDialog loadSQLQueryDialog;
+    loadSQLQueryDialog.setAcceptMode(QFileDialog::AcceptOpen);
+    loadSQLQueryDialog.setFilter(QDir::Filter::Files);
+    loadSQLQueryDialog.setFileMode(QFileDialog::FileMode::ExistingFile);
+    loadSQLQueryDialog.setNameFilter("*.sql");
+    loadSQLQueryDialog.setViewMode(QFileDialog::ViewMode::Detail);
+
+    set_default_filedialog_dir(&loadSQLQueryDialog);
+
+    if(loadSQLQueryDialog.exec())
+    {
+        QString loadedFileName = loadSQLQueryDialog.selectedFiles().at(0);
+
+        QFile loadFile(loadedFileName);
+        loadFile.open(QFile::OpenModeFlag::ReadOnly);
+
+        QByteArray bufferOfDataToRead = loadFile.readAll();
+        QString dataRead = QString::fromLocal8Bit(bufferOfDataToRead);
+
+        textEditWidgetToLoadSQLInto->setPlainText(dataRead);
+    }
+}

--- a/database.h
+++ b/database.h
@@ -9,6 +9,10 @@
 #include <QSqlQuery>
 #include <QSqlRecord>
 #include <QMessageBox>
+#include <QTextEdit>
+#include <QFileDialog>
+
+#include "settings.h"
 
 class database
 {
@@ -19,6 +23,12 @@ public:
     QStringList get_sql_queries();
 
     QSqlDatabase OpenedDatabase;
+
+    static void save_sql_query(QString sqlQueryTextToBeSaved);
+    static void load_sql_query(QTextEdit * textEditWidgetToLoadSQLInto);
+
+private:
+    static void set_default_filedialog_dir(QFileDialog * dialogToSetDefaultDir);
 };
 
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -6,7 +6,9 @@ MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::MainWindow)
 {
-    ui->setupUi(this);
+    ui->setupUi(this);    
+
+    settings::PathApplication = QCoreApplication::applicationDirPath();
 }
 
 MainWindow::~MainWindow()
@@ -84,7 +86,7 @@ void MainWindow::on_actionOpenDatabase_triggered()
             QString pathToOpenedFile = fileDialog.selectedFiles().at(0);
             //std::string connectionString = "Driver={Microsoft Access Driver (*.mdb, *.accdb)};DSN='';DBQ=" + pathToOpenedFile.toStdString();
 
-            QString pathWorkbookFile = QCoreApplication::applicationDirPath() + QDir::separator() + "System.mdw";
+            QString pathWorkbookFile = settings::PathApplication + QDir::separator() + "System.mdw";
             std::string connectionString = "Driver={Microsoft Access Driver (*.mdb, *.accdb)};Uid=Admin;Pwd=;ExtendedAnsiSQL=1;DBQ=" + pathToOpenedFile.toStdString() + ";" +
                     "SystemDB=" + pathWorkbookFile.toStdString();;
 
@@ -158,5 +160,43 @@ void MainWindow::on_pushButtonExecuteQuery_clicked()
 
             this->render_table(customQuery.record(), customQuery);
         }
+    }
+}
+
+void MainWindow::on_pushButtonSaveQuery_clicked()
+{
+    try
+    {
+        QString sqlQueryTextToSave = this->ui->textEditQuery->toPlainText();
+        if(sqlQueryTextToSave == "")
+        {
+            QMessageBox emptySQLText;
+            emptySQLText.setText("Require SQL text to save.");
+            emptySQLText.setIcon(QMessageBox::Icon::Information);
+            emptySQLText.setModal(true);
+            emptySQLText.exec();
+        }
+        else
+        {
+            database::save_sql_query(this->ui->textEditQuery->toPlainText());
+        }
+    }
+    catch(const std::exception &ex)
+    {
+        std::string errorMessage("Encountered error [" + std::string(ex.what()) + "]");
+        this->display_message(errorMessage);
+    }
+}
+
+void MainWindow::on_pushButtonLoadQuery_clicked()
+{
+    try
+    {
+        database::load_sql_query(this->ui->textEditQuery);
+    }
+    catch (const std::exception &ex)
+    {
+        std::string errorMessage("Encountered error [" + std::string(ex.what()) + "]");
+        this->display_message(errorMessage);
     }
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -28,10 +28,10 @@ namespace Ui
     private slots:
         void on_actionOpenDatabase_triggered();
         void on_listDBTables_currentRowChanged(int currentRow);
-
         void on_pushButtonExecuteQuery_clicked();
-
         void on_listWidgetDBQueries_currentRowChanged(int currentRow);
+        void on_pushButtonSaveQuery_clicked();
+        void on_pushButtonLoadQuery_clicked();
 
     private:
         Ui::MainWindow *ui;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -26,8 +26,33 @@
       <property name="title">
        <string>SQL Query:</string>
       </property>
-      <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
-       <item row="1" column="0">
+      <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0,0">
+       <item row="0" column="0" colspan="5">
+        <widget class="QTextEdit" name="textEditQuery">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="acceptRichText">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -37,13 +62,13 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>120</width>
+           <width>150</width>
            <height>20</height>
           </size>
          </property>
         </spacer>
        </item>
-       <item row="1" column="1">
+       <item row="3" column="2">
         <widget class="QPushButton" name="pushButtonSaveQuery">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -68,7 +93,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="2">
+       <item row="3" column="4">
         <widget class="QPushButton" name="pushButtonExecuteQuery">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -93,28 +118,29 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="0" colspan="3">
-        <widget class="QTextEdit" name="textEditQuery">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+       <item row="3" column="1">
+        <widget class="QPushButton" name="pushButtonLoadQuery">
          <property name="minimumSize">
           <size>
-           <width>0</width>
-           <height>30</height>
+           <width>25</width>
+           <height>25</height>
           </size>
          </property>
          <property name="maximumSize">
           <size>
-           <width>16777215</width>
-           <height>30</height>
+           <width>115</width>
+           <height>25</height>
           </size>
          </property>
-         <property name="acceptRichText">
-          <bool>false</bool>
+         <property name="text">
+          <string>Load Query</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="3">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
         </widget>
        </item>

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,0 +1,8 @@
+#include "settings.h"
+
+settings::settings()
+{
+
+}
+
+QString settings::PathApplication;

--- a/settings.h
+++ b/settings.h
@@ -1,0 +1,15 @@
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+#pragma once
+#include <QString>
+
+class settings
+{
+public:
+    settings();
+
+    static QString PathApplication;
+};
+
+#endif // SETTINGS_H


### PR DESCRIPTION
Static functions added to database.cpp to allow load/save sql buttons on the
main GUI to execute logic that handles
these actions. Set default filedialog
directory function to point to a
pre-defined location for .sql scripts. Settings class created to store
application-wide settings, which should
be accessible from anywhere in the
application. PathApplication set at
the main window UI construction
time to ensure it is set during runtime
of application.